### PR TITLE
feat: test with led registers before initialize logic

### DIFF
--- a/selftests/selftests.h
+++ b/selftests/selftests.h
@@ -1,5 +1,5 @@
-#ifndef SELFTEST_H
-#define SELFTEST_H
+#ifndef SELFTESTS_H
+#define SELFTESTS_H
 #include "../src/hw.h"
 int ixgbe_run_diagnostic(const struct hw* hw);
 int ixgbe_test_mmio(const struct hw* hw);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Adds a small pre-initialization self-test module that verifies MMIO register read/write behavior against the IXGBE LED control register before full hardware initialization.

## Changes
- New files:
  - `selftests/ixgbe_mmio.c` — implements ixgbe_run_diagnostic() and ixgbe_test_mmio().
  - `selftests/selftests.h` — public declarations for the two functions.

## Functionality
- ixgbe_run_diagnostic(const struct hw* hw)
  - Thin entry point that calls ixgbe_test_mmio and returns its result.
- ixgbe_test_mmio(const struct hw* hw)
  - Reads and saves IXGBE_LEDCTL into origin_state.
  - Returns -1 if the read returns 0xFFFFFFFF (indicates bus/error).
  - Builds a test pattern by applying IXGBE_LED_CONF(..., 0x8E) for LEDs 0–3.
  - Writes the test pattern, reads back, and verifies the written bits using IXGBE_LED_RW_MASK.
  - Restores origin_state and verifies restoration.
  - Returns 0 on success, -1 on any verification failure.

## Assessment
- Strengths:
  - Provides a lightweight diagnostic that preserves hardware state by backing up and restoring the register.
  - Detects obvious MMIO failures (bus errors, write-not-persisting).
  - Minimal and focused — suitable as an early pre-init check.

- Concurrency considerations:
  - The test uses an unsynchronized read-modify-write sequence. If other code can access IXGBE_LEDCTL concurrently, race conditions may cause false failures (writes between test steps or during restoration). If this test can run while driver runtime code is active, introduce synchronization (spinlock or serialize access) or ensure it runs strictly before other accesses.

- Edge cases and suggestions:
  - Treating 0xFFFFFFFF as an error is appropriate for bus/fault detection, but verify this aligns with target platform semantics.
  - The code assumes IXGBE_LED_RW_MASK captures the writable bits; confirm mask correctness against the hardware spec.
  - Consider adding a small delay or read-after-write retry for flaky hardware that requires settling time.
  - Error returns are coarse (-1); if callers need finer diagnostics, consider distinct error codes or logging hooks.

Overall, the change is small, focused, and appropriate for a pre-init diagnostic with the caveat to address concurrent access if the test may run while the driver is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->