### PR TITLE
docs: formalize architectural design and roadmap for ixgbe PoC

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,22 +8,22 @@ This repository contains proof of concept ixgbe driver for the architecture deta
 Even the architecture is designed for mlx5 driver, proof of concept driver is leveraging 82599.
 Some of the reasons are:
   - **Direct Register Manipulation**
-  Instead of sending commands to 'mailbox[#]_',
+  Instead of sending commands to 'mailbox[1]',
   direct register manipulation considered more transparent when it comes to
   understand & optimize on low level.
    As a trade-off, even this may mean compromising latency, 82599 is preferred because
     modern NICs possess multilayered abstractions.
   - **Defined hardware behavior & Transparent documentation**
   82599 Datasheet is crystal clear, and potential edge cases are documented over the years.
-  As mentioned in previous title, even initializing a 82599 ASIC like playing with electrons manually.
+  As mentioned in previous title, even initializing a 82599 ASIC vibes like playing with electrons manually.
   Similar attempt on a modern NIC would feel like sending mails to 'mailbox', since it is.
   - **Simpler Internal Logic**
-  As a ASIC which released in July 2011, of course it's simpler than modern NIC ASIC's.
+  As an ASIC which released in July 2011, of course it's simpler than modern NIC ASICs.
   When it comes to architecture, lean & mean is preferred.
-  Except few features(e.g, WQE inlining on Mellanox), a good many of the offered
+  Except few features(e.g, WQE inlining on Mellanox), many of the offered
   features are bloat for low latency goal.
-With this points are kept in mind, 82599 is selected for proof or concept,
-and modern Mellanox NIC's ( Model may vary) is selected for going production,
+With these points are kept in mind, 82599 is selected for proof of concept,
+and modern Mellanox NICs ( Model may vary) is selected for going production,
 if the architecture designed works well enough on 82599.
 This work aims proving the architecture and become aware of situations
 not taken into consideration.
@@ -34,23 +34,23 @@ Architectural design principles
     This title includes keeping everything that doesn't help us achieve the goal out.
     For example In this proof of concept on icmp protocol,
     Checksums are not validated upon ingress,
-    and doesn't going to recalculated on replying. Instead, RFC 1624 is used.
+    and is will not be recalculated on replying. Instead, RFC 1624 is used.
     Destination IP is not going to be checked. Instead, the logic will just switch
     destination and source IP's.
-    As can be seen in this points, a newly packet will not be generated. Instead,
+    As can be seen in these points, a new packet will not be generated. Instead,
     received packet will be edited and bumped to wire as soon as possible.
     - **Inlining Workload with Driver**
     This section holds a critical place among the ideas of this project.
-    Even if it is hard to maintain, portability is impossible on specific NIC logic,
-    (e.g, Initializing 882599 part on TO-DO.) if it's profitable, it can be made.
+    Even if it is hard to maintain, portability is impossible on NIC-specific logic,
+    (e.g, Initializing 82599 part on TO-DO) if it's profitable, it can be made.
 If this repository succeeds and continued, this question will be answered on a article.
-In the continued implementation, Mellanox ASIC's will be used, and features like WQE inlining are leveraged.
+In the continued implementation, Mellanox ASICs will be used, and features like WQE inlining are leveraged.
 HFT vision of Mellanox is dates back to 2012.
 See https://network.nvidia.com/files/pdf/whitepapers/SB_HighFreq_Trading.pdf for details.
 TO-DO
 -----
 
-* |ballot| **Setting Environment **
+* |ballot| **Setting Environment**
     - [x] Unbind device from kernel's control permanently.
     By permanently, preventing kernel from taking control undesirably is meant.
     - [x] Allocate hugepage & map with 'Memory based I/O'.
@@ -58,15 +58,16 @@ TO-DO
 **Tested on bare metal.**
 * |ballot| **Initializing 82599**
     - [x] Architectural designs for performance.
-    Some of this designs are documented in this file, or at |docs|.
-    - [ ] Implement register manipulations following to design made for initializing.
+    Some of these designs are documented in this file, or at the /docs directory.
+    - [ ] Implement register manipulations following the design made for initializing.
     Work in progress. With Pull Requests section, it can be observed.
     - [ ] Tx/Rx ring management.
-* |ballot| **Rewriting ICMP from scratch to benchmark **
+* |ballot| **Rewriting ICMP from scratch to benchmark**
     - [ ] Implement logic based on design made.
     - [ ] Collecting metrics and analysis.
-After that analysis, implementing future logic, will be decided.
-.. [#] Mellanox Firmware Design Architecture, see Programmer's Reference Manual.
-Couldn't refer to a topic or page because it's mentioned in many.
+    After that analysis, implementing future logic, will be decided.
+[1] Mellanox Firmware Design Architecture, see Programmer's Reference Manual.
+Could not refer to a topic or page because it's mentioned in many.
 Note that PRM's are not public, but ConnectX-4.
-.. |docs| image:: /docs/
+
++.. |ballot| unicode:: U+2610 .. empty box

--- a/docs/error_handling.rst
+++ b/docs/error_handling.rst
@@ -37,7 +37,6 @@ branches.
 Branch prediction is also mentioned in :ref:`happy_path_logic`,
 Below title 'Happy path is fast, error path is not'.
 Within the examination of a function with objdump, it can be proven.
-
 Used command : 'objdump -d src/init.o'
 
 .. code-block:: console


### PR DESCRIPTION
I'm aware of RST-based errors, and they are not fixed before sending a pull request intentionally, since it's already going to be fixed by coderabbit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Documentation: formalized architecture and roadmap for ixgbe PoC

Scope
- Converts a terse project header into a structured architectural design document and roadmap for the ixgbe userspace PoC (focus: low-latency workloads, Intel 82599 PoC with production target on Mellanox).

Key changes
- README.rst (+71/-6 lines)
  - Expanded introduction and architectural rationale (why 82599 for PoC, planned move to Mellanox/WQE inlining for production).
  - Two explicit design principles: Radical Cropping (minimal packet processing, RFC 1624 usage, in-place packet edits) and Inlining Workload with Driver (tradeoffs between portability and performance).
  - Concrete TO-DO ballots: environment setup, 82599 initialization, Tx/Rx ring work, ICMP rewrite and benchmarking; checkboxes reflect current progress.
  - References Mellanox HFT whitepaper and PRM; documents intentions for future measurement/analysis.
  - Minor formatting/artifact text present (unicode ballot marker, footnote phrasing) requiring a quick editorial pass.

- docs/error_handling.rst (+1 line)
  - Minor formatting insertion after the objdump command; file documents branch-layout/error-path strategy and includes an objdump excerpt demonstrating hot/cold path layout.

Public API / exported entities
- No changes.

Impact & assessment
- Documentation now provides necessary architectural context and explicit next steps for continuing the PoC. Useful for reviewers and contributors to understand design tradeoffs and implementation plan.
- No code changes; no new race-condition or API surface introduced by this PR. However, the architecture intentionally favors aggressive latency optimizations (in-place packet editing, disabled checksum validation in PoC) — these tradeoffs and safety/edge-case mitigations should be revisited before any production migration.
- Editorial/formatting items remain (README ballot/footnote artifacts, some phrasing); recommend a focused doc cleanup pass and clarifying the non-public PRM reference.

Files changed (summary)
- README.rst: +71 / -6
- docs/error_handling.rst: +1 / -0

Recommended next review actions
- Editorial pass to fix remaining RST/formatting artifacts and clarify references.
- Review TO-DO items and split into tracked issues/PRs for implementation, testing, and safety checks (checksum handling, packet validation, concurrency/ring management).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->